### PR TITLE
version 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 `MultiLevelFormatter` is a Python `logging.Formatter` that simplifies setting log formats for different log levels. Log records with level `logging.ERROR` or higher are printed to STDERR if using defaults with `MultilevelFormatter.setDefaults()`.
 
-Importing `MultiLevelFormatter` adds MESSAGE level (`25`) to logging and an `logging.message()` method. The idea is that you can use `logging.message()` instead of `print()` and use logging levels to control verbosity. See the full example below.  
-
 
 ## Install
 
@@ -15,15 +13,12 @@ pip install multilevelformatter
 
 ## Usage
 
-*Please note.* If you use `mypy`, you need to add `# type: ignore` to the lines assigning `logging.message` to `message` (function) and whenever using `logging.MESSAGE` log level name. In practice this will be few lines in a module. `mypy` does not recognize the modifications to the `logging` class that is done when importing `multilevelformatter`. See [mypy#5363](https://github.com/python/mypy/issues/5363) for details.
 
 ```python
 
 logger = logging.getLogger(__name__)
 error = logger.error
-warning = logger.warning
-# added when importing multilevelformatter
-message = logging.message  # type: ignore 
+message = logger.warning
 verbose = logger.info
 debug = logger.debug
 
@@ -35,12 +30,9 @@ def main() -> None:
     # assumes command line arguments have been parsed into 
     # boolean flags: arg_verbose, arg_debug, arg_silent
     
-    # MultiLevelFormatter adds MESSAGE level (25) to logging
-    LOG_LEVEL: int = logging.MESSAGE # type: ignore 
+    LOG_LEVEL: int = logging.WARNING
     if arg_verbose: 
         LOG_LEVEL = logging.INFO
-    elif arg_warning:
-        LOG_LEVEL = logging.WARNING
     elif arg_debug:
         LOG_LEVEL = logging.DEBUG
     elif arg_silent:
@@ -65,8 +57,7 @@ from multilevelformatter import MultilevelFormatter
 
 logger = logging.getLogger(__name__)
 error = logger.error
-# MultiLevelFormatter adds MESSAGE level and message() to logging
-message =  logger.message # type: ignore 
+message =  logger.warning 
 verbose = logger.info
 debug = logger.debug
 
@@ -107,15 +98,14 @@ def cli(
     global logger
 
     try:
-        LOG_LEVEL: int = logging.MESSAGE # type: ignore 
+        LOG_LEVEL: int = logging.WARNING
         if print_verbose:
             LOG_LEVEL = logging.INFO
         elif print_debug:
             LOG_LEVEL = logging.DEBUG
         elif print_silent:
             LOG_LEVEL = logging.ERROR
-        MultilevelFormatter.setDefaults(logger, log_file=log)
-        logger.setLevel(LOG_LEVEL)
+        MultilevelFormatter.setDefaults(logger, log_file=log, level=LOG_LEVEL)        
     except Exception as err:
         error(f"{err}")
     message("standard")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 
+dependencies = ["Deprecated>=1.2.14"]
+
 [project.optional-dependencies]
 dev = [
     "build>=0.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "multilevelformatter"
-version = "0.3.5"
+version = "0.4.0"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "logger.Formatter to simplify setting formatting for multiple logging levels"
 readme = "README.md"

--- a/src/multilevelformatter/__init__.py
+++ b/src/multilevelformatter/__init__.py
@@ -1,6 +1,8 @@
 from .multilevelformatter import (
     MultilevelFormatter as MultilevelFormatter,
-    # set_mlevel_logging as set_mlevel_logging,
+    addLoggingLevel as addLoggingLevel,
+    addLoggingLevelMessage as addLoggingLevelMessage,
+    MESSAGE as MESSAGE,
 )
 
 __all__ = [

--- a/src/multilevelformatter/multilevelformatter.py
+++ b/src/multilevelformatter/multilevelformatter.py
@@ -62,7 +62,11 @@ def addLoggingLevel(
     setattr(logging, methodName, logToRoot)
 
 
-addLoggingLevel("MESSAGE", logging.WARNING - 5)
+def addLoggingLevelMessage() -> None:
+    """
+    Add  logging level logging.MESSAGE to the root logger with value 25
+    """
+    addLoggingLevel("MESSAGE", logging.WARNING - 5)
 
 
 class MultilevelFormatter(logging.Formatter):

--- a/src/multilevelformatter/multilevelformatter.py
+++ b/src/multilevelformatter/multilevelformatter.py
@@ -3,6 +3,10 @@ import sys
 from typing import Literal, Optional, Dict, ClassVar, List
 from pathlib import Path
 
+from deprecated import deprecated  # type: ignore
+
+# from icecream import ic  # type: ignore
+
 
 def addLoggingLevel(
     levelName: str, levelNum: int, methodName: str | None = None
@@ -117,13 +121,34 @@ class MultilevelFormatter(logging.Formatter):
                 defaults=defaults,
             )
 
-        for level in fmts.keys():
-            self._formatters[level] = logging.Formatter(fmt=fmts[level], style=style)
-
     @classmethod
+    @deprecated(version="0.5", reason="Renamed, please use setFormats() instead")
     def setLevels(
         cls,
         logger: logging.Logger,
+        fmts: Dict[int, str],
+        fmt: Optional[str] = None,
+        datefmt: Optional[str] = None,
+        style: Literal["%", "{", "$"] = "%",
+        validate: bool = True,
+        log_file: Optional[str | Path] = None,
+    ) -> None:
+        """
+        DEPRECIATED: Use setFormats()
+
+        Will be removed
+
+        Setup logging format for multiple levels
+        """
+        cls.setFormats(
+            logger=logger,
+            fmts=fmts,
+            fmt=fmt,
+            datefmt=datefmt,
+            style=style,
+            validate=validate,
+            log_file=log_file,
+        )
 
     @classmethod
     def setFormats(

--- a/src/multilevelformatter/multilevelformatter.py
+++ b/src/multilevelformatter/multilevelformatter.py
@@ -124,36 +124,45 @@ class MultilevelFormatter(logging.Formatter):
     def setLevels(
         cls,
         logger: logging.Logger,
-        fmts: Optional[Dict[int, str]] = None,
+
+    @classmethod
+    def setFormats(
+        cls,
+        logger: logging.Logger,
+        fmts: Dict[int, str],
         fmt: Optional[str] = None,
         datefmt: Optional[str] = None,
         style: Literal["%", "{", "$"] = "%",
         validate: bool = True,
         log_file: Optional[str | Path] = None,
     ) -> None:
-        """Setup logging"""
-        if fmts is not None:
+        """
+        Setup logging format for multiple levels
+        """
+        try:
             multi_formatter = MultilevelFormatter(
-                fmt=fmt, fmts=fmts, datefmt=datefmt, style=style, validate=validate
+                fmts=fmts, fmt=fmt, datefmt=datefmt, style=style, validate=validate
             )
             # log all but errors to STDIN
             stream_handler = logging.StreamHandler(sys.stdout)
             stream_handler.addFilter(lambda record: record.levelno < logging.ERROR)
             stream_handler.setFormatter(multi_formatter)
             logger.addHandler(stream_handler)
-
             # log errors and above to STDERR
             error_handler = logging.StreamHandler(sys.stderr)
             error_handler.setLevel(logging.ERROR)
             error_handler.addFilter(lambda record: record.levelno >= logging.ERROR)
             error_handler.setFormatter(multi_formatter)
             logger.addHandler(error_handler)
-
-        if log_file is not None:
-            file_handler = logging.FileHandler(log_file)
-            log_formatter = logging.Formatter(fmt=fmt, style=style, validate=validate)
-            file_handler.setFormatter(log_formatter)
-            logger.addHandler(file_handler)
+            if log_file is not None:
+                file_handler = logging.FileHandler(log_file)
+                log_formatter = logging.Formatter(
+                    fmt=fmt, style=style, validate=validate
+                )
+                file_handler.setFormatter(log_formatter)
+                logger.addHandler(file_handler)
+        except Exception as err:
+            logging.error(f"Could not set formats: {err}")
 
     @classmethod
     def setDefaults(


### PR DESCRIPTION
- `setFormats()` to replace `setLevels()`. The latter is not deprecated.
- Removed custom `logging.MESSAGE` from `setDefaults()` since `mypy` does not like injecting new attributes to packages from outside